### PR TITLE
feat: add Azure Function App modul

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,13 +15,13 @@ This catalog provides production-ready, validated Bicep modules for enterprise A
 
 ## 📦 Module Catalog
 
-**Total: 27 modules across 8 categories**
+**Total: 28 modules across 8 categories**
 
 | Category | Modules | Description |
 |----------|---------|-------------|
 | [Network](catalog/network/) | 9 | Hub-spoke networking, Azure Firewall, Bastion, VPN, DNS |
 | [AI & ML](catalog/ai/) | 3 | Azure OpenAI, AI Search, Machine Learning Workspace |
-| [Compute & Web](catalog/compute/) | 2 | App Service Plans, Web Apps |
+| [Compute & Web](catalog/compute/) | 3 | App Service Plans, Web Apps, Function Apps |
 | [Containers](catalog/containers/) | 2 | Container Apps Environment, Container Apps |
 | [Data & Messaging](catalog/data/) | 5 | Redis, Cosmos DB, SQL, PostgreSQL, Service Bus |
 | [Storage](catalog/storage/) | 2 | Storage Accounts, Container Registries |

--- a/catalog/README.md
+++ b/catalog/README.md
@@ -26,8 +26,9 @@ AI services for Microsoft Foundry workloads
 Application hosting and web services
 - App Service Plans
 - App Services (Web Apps)
+- Function Apps (Serverless)
 
-**Total: 2 modules**
+**Total: 3 modules**
 
 ### 💾 [Storage Modules](storage/)
 Data storage and container management

--- a/catalog/compute/README.md
+++ b/catalog/compute/README.md
@@ -6,8 +6,9 @@ Azure Verified Modules for compute and web services in the Microsoft Foundry lan
 
 | Module | AVM Reference | Version | Description |
 |--------|--------------|---------|-------------|
-| [App Service Plan](app-service-plan.bicep) | `avm/res/web/serverfarm` | 0.3.0 | App Service Plan for hosting |
-| [App Service](app-service.bicep) | `avm/res/web/site` | 0.9.0 | App Service (Web App) for chat UI |
+| [App Service Plan](app-service-plan/) | `avm/res/web/serverfarm` | 0.6.0 | App Service Plan for hosting |
+| [App Service](app-service/) | `avm/res/web/site` | 0.21.0 | App Service (Web App) for web applications |
+| [Function App](function-app/) | `avm/res/web/site` | 0.8.0 | Azure Function App for serverless compute |
 
 ## Usage Example
 

--- a/catalog/compute/function-app/0.8.0/README.md
+++ b/catalog/compute/function-app/0.8.0/README.md
@@ -1,0 +1,88 @@
+# Function App Module
+
+## Overview
+
+This module deploys an Azure Function App using Azure Verified Modules (AVM). Azure Functions is a serverless compute service that enables you to run event-driven code without having to explicitly provision or manage infrastructure.
+
+## Module Reference
+
+- **AVM Module**: `br/public:avm/res/web/site:0.8.0`
+- **Documentation**: [GitHub - AVM Module](https://github.com/Azure/bicep-registry-modules/tree/main/avm/res/web/site)
+
+## Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `name` | string | Required | The name of the function app |
+| `location` | string | `resourceGroup().location` | The Azure region for deployment |
+| `serverFarmResourceId` | string | Required | App Service Plan resource ID |
+| `kind` | string | `'functionapp'` | Kind of site (use `functionapp` for Windows or `functionapp,linux` for Linux) |
+| `siteConfig` | object | `{}` | Site configuration settings |
+| `appSettingsKeyValuePairs` | object | `{}` | Additional app settings key-value pairs |
+| `virtualNetworkSubnetId` | string | `''` | Virtual network subnet ID for VNet integration |
+| `privateEndpoints` | array | `[]` | Array of private endpoint configurations |
+| `managedIdentities` | object | `{}` | Managed identity configuration |
+| `tags` | object | `{}` | Resource tags |
+| `storageAccountResourceId` | string | `''` | Storage account resource ID (required for function app) |
+| `storageAccountName` | string | `''` | Storage account name (required for function app) |
+| `applicationInsightsResourceId` | string | `''` | Application Insights resource ID for monitoring |
+| `functionAppRuntime` | string | `'dotnet'` | Function app runtime (dotnet, node, python, java, powershell, custom) |
+| `functionAppRuntimeVersion` | string | `'8'` | Function app runtime version |
+
+## Outputs
+
+| Output | Type | Description |
+|--------|------|-------------|
+| `resourceId` | string | The resource ID of the function app |
+| `name` | string | The name of the function app |
+| `defaultHostname` | string | The default hostname of the function app |
+| `systemAssignedPrincipalId` | string | The principal ID of the system-assigned managed identity |
+
+## Usage
+
+### Basic Deployment
+
+See [examples/basic-deployment.bicep](examples/basic-deployment.bicep) for a minimal configuration.
+
+### Production Deployment
+
+See [examples/production-deployment.bicep](examples/production-deployment.bicep) for a production-ready configuration with VNet integration and private endpoints.
+
+## Example
+
+```bicep
+module functionApp '../function-app/0.8.0/main.bicep' = {
+  name: 'function-app-deployment'
+  params: {
+    name: 'my-function-app'
+    location: 'eastus'
+    serverFarmResourceId: appServicePlan.outputs.resourceId
+    storageAccountResourceId: storage.outputs.resourceId
+    storageAccountName: storage.outputs.name
+    applicationInsightsResourceId: appInsights.outputs.resourceId
+    functionAppRuntime: 'dotnet'
+    functionAppRuntimeVersion: '8'
+    managedIdentities: {
+      systemAssigned: true
+    }
+    tags: {
+      environment: 'production'
+      application: 'my-app'
+    }
+  }
+}
+```
+
+## Notes
+
+- Azure Functions requires a storage account for storing function app state and logs
+- Application Insights is highly recommended for monitoring and diagnostics
+- The module automatically configures required app settings like `AzureWebJobsStorage`, `WEBSITE_CONTENTAZUREFILECONNECTIONSTRING`, and `FUNCTIONS_EXTENSION_VERSION`
+- For Linux function apps, set `kind` to `'functionapp,linux'`
+- Supported runtimes: dotnet, node, python, java, powershell, custom
+
+## Related Modules
+
+- [App Service Plan](../../app-service-plan/)
+- [Storage Account](../../../storage/storage-account/)
+- [Application Insights](../../../monitoring/application-insights/)

--- a/catalog/compute/function-app/0.8.0/examples/basic-deployment.bicep
+++ b/catalog/compute/function-app/0.8.0/examples/basic-deployment.bicep
@@ -1,0 +1,32 @@
+// Basic deployment of Azure Function App
+targetScope = 'resourceGroup'
+
+param location string = 'eastus'
+param environment string = 'dev'
+param serverFarmResourceId string
+param storageAccountResourceId string
+param storageAccountName string
+
+module functionApp '../main.bicep' = {
+  name: 'function-app-basic'
+  params: {
+    name: 'func-${environment}-${uniqueString(resourceGroup().id)}'
+    location: location
+    serverFarmResourceId: serverFarmResourceId
+    storageAccountResourceId: storageAccountResourceId
+    storageAccountName: storageAccountName
+    functionAppRuntime: 'dotnet'
+    functionAppRuntimeVersion: '8'
+    managedIdentities: {
+      systemAssigned: true
+    }
+    tags: {
+      environment: environment
+      deploymentType: 'basic'
+    }
+  }
+}
+
+output resourceId string = functionApp.outputs.resourceId
+output name string = functionApp.outputs.name
+output defaultHostname string = functionApp.outputs.defaultHostname

--- a/catalog/compute/function-app/0.8.0/examples/production-deployment.bicep
+++ b/catalog/compute/function-app/0.8.0/examples/production-deployment.bicep
@@ -1,0 +1,62 @@
+// Production deployment of Azure Function App with VNet integration and private endpoints
+targetScope = 'resourceGroup'
+
+param location string = 'eastus'
+param environment string = 'prod'
+param serverFarmResourceId string
+param storageAccountResourceId string
+param storageAccountName string
+param applicationInsightsResourceId string
+param virtualNetworkSubnetId string
+param privateEndpointSubnetId string
+param privateDnsZoneResourceId string
+
+module functionApp '../main.bicep' = {
+  name: 'function-app-production'
+  params: {
+    name: 'func-${environment}-${uniqueString(resourceGroup().id)}'
+    location: location
+    kind: 'functionapp,linux'
+    serverFarmResourceId: serverFarmResourceId
+    storageAccountResourceId: storageAccountResourceId
+    storageAccountName: storageAccountName
+    applicationInsightsResourceId: applicationInsightsResourceId
+    functionAppRuntime: 'dotnet'
+    functionAppRuntimeVersion: '8'
+    virtualNetworkSubnetId: virtualNetworkSubnetId
+    managedIdentities: {
+      systemAssigned: true
+    }
+    privateEndpoints: [
+      {
+        name: 'pe-func-${environment}'
+        subnetResourceId: privateEndpointSubnetId
+        privateDnsZoneResourceIds: [
+          privateDnsZoneResourceId
+        ]
+        service: 'sites'
+      }
+    ]
+    siteConfig: {
+      linuxFxVersion: 'DOTNET-ISOLATED|8.0'
+      alwaysOn: true
+      ftpsState: 'Disabled'
+      minTlsVersion: '1.2'
+      http20Enabled: true
+    }
+    appSettingsKeyValuePairs: {
+      WEBSITE_RUN_FROM_PACKAGE: '1'
+      WEBSITE_ENABLE_SYNC_UPDATE_SITE: 'true'
+    }
+    tags: {
+      environment: environment
+      deploymentType: 'production'
+      costCenter: 'engineering'
+    }
+  }
+}
+
+output resourceId string = functionApp.outputs.resourceId
+output name string = functionApp.outputs.name
+output defaultHostname string = functionApp.outputs.defaultHostname
+output systemAssignedPrincipalId string = functionApp.outputs.systemAssignedPrincipalId

--- a/catalog/compute/function-app/0.8.0/main.bicep
+++ b/catalog/compute/function-app/0.8.0/main.bicep
@@ -1,0 +1,86 @@
+// Azure Verified Module Reference: Function App
+// Registry: br/public:avm/res/web/site
+
+metadata name = 'Function App'
+metadata description = 'AVM reference for deploying Azure Function App'
+metadata owner = 'Azure Verified Modules'
+
+@description('The name of the function app')
+param name string
+
+@description('The location')
+param location string = resourceGroup().location
+
+@description('App Service Plan resource ID')
+param serverFarmResourceId string
+
+@description('Kind of site - use functionapp for Windows or functionapp,linux for Linux')
+param kind string = 'functionapp'
+
+@description('Site configuration')
+param siteConfig object = {}
+
+@description('App settings')
+param appSettingsKeyValuePairs object = {}
+
+@description('Virtual network subnet ID for integration')
+param virtualNetworkSubnetId string = ''
+
+@description('Enable private endpoints')
+param privateEndpoints array = []
+
+@description('Managed identity configuration')
+param managedIdentities object = {}
+
+@description('Tags')
+param tags object = {}
+
+@description('Storage account resource ID for function app')
+param storageAccountResourceId string = ''
+
+@description('Storage account name for function app')
+param storageAccountName string = ''
+
+@description('Application Insights resource ID')
+param applicationInsightsResourceId string = ''
+
+@description('Function app runtime (dotnet, node, python, java, powershell, custom)')
+param functionAppRuntime string = 'dotnet'
+
+@description('Function app runtime version')
+param functionAppRuntimeVersion string = '8'
+
+module functionApp 'br/public:avm/res/web/site:0.8.0' = {
+  name: '${name}-deployment'
+  params: {
+    name: name
+    location: location
+    kind: kind
+    serverFarmResourceId: serverFarmResourceId
+    appSettingsKeyValuePairs: union(
+      !empty(appSettingsKeyValuePairs) ? appSettingsKeyValuePairs : {},
+      !empty(storageAccountName) ? {
+        AzureWebJobsStorage: 'DefaultEndpointsProtocol=https;AccountName=${storageAccountName};EndpointSuffix=${environment().suffixes.storage};AccountKey=${listKeys(storageAccountResourceId, '2021-09-01').keys[0].value}'
+        WEBSITE_CONTENTAZUREFILECONNECTIONSTRING: 'DefaultEndpointsProtocol=https;AccountName=${storageAccountName};EndpointSuffix=${environment().suffixes.storage};AccountKey=${listKeys(storageAccountResourceId, '2021-09-01').keys[0].value}'
+        WEBSITE_CONTENTSHARE: toLower(name)
+      } : {},
+      !empty(applicationInsightsResourceId) ? {
+        APPLICATIONINSIGHTS_CONNECTION_STRING: reference(applicationInsightsResourceId, '2020-02-02').ConnectionString
+      } : {},
+      {
+        FUNCTIONS_EXTENSION_VERSION: '~4'
+        FUNCTIONS_WORKER_RUNTIME: functionAppRuntime
+      }
+    )
+    siteConfig: siteConfig
+    virtualNetworkSubnetId: virtualNetworkSubnetId
+    privateEndpoints: privateEndpoints
+    managedIdentities: managedIdentities
+    tags: tags
+  }
+}
+
+output resourceId string = functionApp.outputs.resourceId
+output name string = functionApp.outputs.name
+output defaultHostname string = functionApp.outputs.defaultHostname
+output systemAssignedPrincipalId string = functionApp.outputs.systemAssignedMIPrincipalId


### PR DESCRIPTION
This pull request adds a new Azure Function App module to the catalog, expanding the available compute and web modules. The update includes documentation, usage examples, and integration with related modules, making it easier to deploy and manage serverless compute workloads using Azure Verified Modules (AVM).

**Key changes:**

**New Function App Module:**
- Added a production-ready Function App module (`catalog/compute/function-app/0.8.0`) with a detailed README, parameters, outputs, and notes for deploying Azure Function Apps using AVM.
- Included example Bicep files for both basic and production deployments, demonstrating usage patterns and advanced features like VNet integration and private endpoints. 

**Catalog and Documentation Updates:**
- Updated the main module catalog in `README.md` and `catalog/README.md` to reflect the addition of the Function App module, increasing the Compute & Web category from 2 to 3 modules.
- Enhanced the compute module table in `catalog/compute/README.md` to include the new Function App module, with updated references and descriptions for all compute modules.